### PR TITLE
Speed up rebuilds and tweak the workflow for writing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,25 @@ to 10 seconds.
 By convention, for each of the services, the `dev` profile is activated.  This
 means that one can store development-specific properties in
 `application-dev.EXT`, where `EXT` is `yml` or `properties`.
+
+## Writing migrations
+This project uses
+[Flyway](https://documentation.red-gate.com/fd/migrations-271585107.html)
+([Spring specific
+docs](https://docs.spring.io/spring-boot/how-to/data-initialization.html#howto.data-initialization.migration-tool.flyway))
+to perform migrations on databases.
+
+<!-- TODO brief summary -->
+
+### Development container specifics
+This project uses Hibernate ORM.
+
+The development container provides configuration for Hibernate to emit DDL it
+believes is correct for the entities specified in the codebase to the standard
+error output of the service.  You can, hence, read the DDL Hibernate expects to
+see from the respective container logs in order to write migrations.
+
+The `db/migration` directory is ignored by Docker Watch.  This is because
+it is too easy to run partially-written migrations if they are watched, and it
+is difficult to reapply a migration.  When you're certain you've finished a
+migration, restart the respective service to start the migrations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       POSTGRES_PASSWORD: lmaolmao123
       POSTGRES_DB: user-service
       POSTGRES_USER: user-service
+    volumes:
+      - user_service_db_data:/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -d user-service -U user-service"
       interval: 3s
@@ -107,6 +109,8 @@ services:
       POSTGRES_PASSWORD: lmaolmao123
       POSTGRES_DB: notification-service
       POSTGRES_USER: notification-service
+    volumes:
+      - notification_service_db_data:/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -d notification-service -U notification-service"
       interval: 3s
@@ -124,3 +128,6 @@ services:
 volumes:
   user_service_gradle:
   notification_service_gradle:
+  # Database storage persistence.
+  notification_service_db_data:
+  user_service_db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
         - action: sync+restart
           path: ./user-service/src
           target: /code/src
+          ignore:
+            - main/resources/db/migration
         - action: sync+restart
           path: ./user-service/build.gradle.kts
           target: /code/build.gradle.kts
@@ -78,6 +80,8 @@ services:
         - action: sync+restart
           path: ./notification-service/src
           target: /code/src
+          ignore:
+            - main/resources/db/migration
         - action: sync+restart
           path: ./notification-service/build.gradle.kts
           target: /code/build.gradle.kts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
         condition: service_healthy
       broker:
         condition: service_started
+    volumes:
+      - user_service_gradle:/home/service/.gradle
+    post_start:
+      - command: "chown -R service: /home/service/.gradle"
+        user: root
     develop:
       watch:
         - action: sync+restart
@@ -75,6 +80,11 @@ services:
         condition: service_healthy
       broker:
         condition: service_started
+    volumes:
+      - notification_service_gradle:/home/service/.gradle
+    post_start:
+      - command: "chown -R service: /home/service/.gradle"
+        user: root
     develop:
       watch:
         - action: sync+restart
@@ -110,3 +120,7 @@ services:
     ports:
       # Management interface.
       - "15672:15672"
+
+volumes:
+  user_service_gradle:
+  notification_service_gradle:

--- a/docker/run-service.sh
+++ b/docker/run-service.sh
@@ -18,7 +18,7 @@
 set -xe
 ( # Build
     cd /code
-    ./gradlew --no-daemon bootJar
+    ./gradlew --build-cache --no-daemon bootJar
 )
 
 cd /service

--- a/notification-service/src/main/resources/application-dev.yml
+++ b/notification-service/src/main/resources/application-dev.yml
@@ -22,3 +22,18 @@ spring:
     # Default credentials used in the dev Compose file.
     username: guest
     password: guest
+
+  # Generate DDL in create-ddl output
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+      javax:
+        persistence:
+          schema-generation:
+            create-source: metadata
+            scripts:
+              action: create
+              create-target: /dev/stderr

--- a/user-service/src/main/resources/application-dev.yml
+++ b/user-service/src/main/resources/application-dev.yml
@@ -23,6 +23,21 @@ spring:
     username: guest
     password: guest
 
+  # Generate DDL in create-ddl output
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+      javax:
+        persistence:
+          schema-generation:
+            create-source: metadata
+            scripts:
+              action: create
+              create-target: /dev/stderr
+
 jwt:
   secret:
     key: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'


### PR DESCRIPTION
With this patchset, the developer gets:
- Hibernate generating DDL onto standard error, so that it may be read by the
  developer in order to write their migrations in accordance with Hibernates
  expectations,
- A faster-rebuilding container, and
- More persistent database data storage (so that one does not loose their state
  when I tweak the database configuration)