### PR TITLE
*: activate and gitignore 'local' Spring Boot profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 *.iml
+
+# Ignore application-local.yml/properties
+application-local.yml
+application-local.properties

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ docker compose exec user_service_db psql -U user-service user-service
 docker compose exec notification_service_db psql -U notification-service notification-service
 ```
 
+### Developer-specific Spring properties
+If you wish to add some developer-specific properties (such as, for instance,
+email credentials for an SMTP server you were using to test something), you
+can place `application-local.properties` or `application-local.yml` in the
+resources directory.
+
+Please do note that these profiles will also be copied into any builds you make
+and also into the tests you run locally, and so, care should be taken not to
+interfere with the testsuite.
+
+The aforementioned files are already ignored.
+
+> [!CAUTION]
+> **PLEASE USE THIS FEATURE SPARINGLY**, it will lead to differences between
+> developer machines, which are very annoying.
+
 ## Writing migrations
 This project uses
 [Flyway](https://documentation.red-gate.com/fd/migrations-271585107.html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "8080:8080"
     command:
       - /code/build/libs/user-service-0.0.1-SNAPSHOT.jar
-      - --spring.profiles.active=dev
+      - --spring.profiles.active=dev,local
     depends_on:
       user_service_db:
         condition: service_healthy
@@ -76,7 +76,7 @@ services:
         SERVICE: notification-service
     command:
       - /code/build/libs/notification-service-0.0.1-SNAPSHOT.jar
-      - --spring.profiles.active=dev
+      - --spring.profiles.active=dev,local
     depends_on:
       notification_service_db:
         condition: service_healthy


### PR DESCRIPTION
This allows developers to keep machine-local or developer-specific Spring configuration locally.

This feature should be used sparingly.  Only for secrets, preferably.