### PR TITLE
buildSrc: fix makeMigration using minutes instead of months

### DIFF
--- a/buildSrc/src/main/kotlin/banka4.migration-generator.gradle.kts
+++ b/buildSrc/src/main/kotlin/banka4.migration-generator.gradle.kts
@@ -21,7 +21,7 @@ abstract class MakeMigrationTask @Inject constructor(
 	fun action() {
 		val currentTime = OffsetDateTime.now(ZoneOffset.UTC);
 		val currentTimeStr = currentTime.format(
-			DateTimeFormatter.ofPattern("YYYY'.'mm'.'dd")
+			DateTimeFormatter.ofPattern("YYYY'.2'MM'.'dd")
 		)
 		val migName = migrationName.get()
 		if (!migName.matches("[a-zA-Z0-9_]+".toRegex()))


### PR DESCRIPTION
also adds a '2' prefix to every month component to make it higher than all minutes