### PR TITLE
Remove `Currency#id`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_style = tab
 [*.java]
 indent_style = space
 indent_size = 4
+
+[*.sql]
+indent_style = space

--- a/user-service/src/main/java/rs/banka4/user_service/domain/currency/db/Currency.java
+++ b/user-service/src/main/java/rs/banka4/user_service/domain/currency/db/Currency.java
@@ -3,7 +3,6 @@ package rs.banka4.user_service.domain.currency.db;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.persistence.*;
 import java.util.Objects;
-import java.util.UUID;
 import lombok.*;
 import org.hibernate.proxy.HibernateProxy;
 import rs.banka4.user_service.exceptions.account.InvalidCurrency;
@@ -13,13 +12,14 @@ import rs.banka4.user_service.exceptions.account.InvalidCurrency;
 @AllArgsConstructor
 @Getter
 @Setter
+@ToString
 @Builder
 @Table(name = "currencies")
 public class Currency {
 
     @Id
-    @Builder.Default
-    private UUID id = UUID.randomUUID();
+    @Enumerated(EnumType.STRING)
+    private Code code;
 
     @Column(nullable = false)
     private String name;
@@ -32,9 +32,6 @@ public class Currency {
 
     @Column(nullable = false)
     private boolean active;
-
-    @Enumerated(EnumType.STRING)
-    private Code code;
 
     public enum Code {
         RSD,
@@ -57,11 +54,6 @@ public class Currency {
     }
 
     @Override
-    public String toString() {
-        return "Currency{" + "id=" + id + ", name='" + name + '\'' + '}';
-    }
-
-    @Override
     public final boolean equals(Object o) {
         if (this == o) return true;
         if (o == null) return false;
@@ -77,7 +69,7 @@ public class Currency {
                 : this.getClass();
         if (thisEffectiveClass != oEffectiveClass) return false;
         Currency currency = (Currency) o;
-        return getId() != null && Objects.equals(getId(), currency.getId());
+        return getCode() != null && Objects.equals(getCode(), currency.getCode());
     }
 
     @Override

--- a/user-service/src/main/java/rs/banka4/user_service/domain/loan/db/LoanRequest.java
+++ b/user-service/src/main/java/rs/banka4/user_service/domain/loan/db/LoanRequest.java
@@ -24,7 +24,7 @@ public class LoanRequest {
     private BigDecimal amount;
 
     @ManyToOne
-    @JoinColumn(name = "currency_id")
+    @JoinColumn(name = "currency_code")
     private Currency currency;
 
     private String employmentStatus;

--- a/user-service/src/main/java/rs/banka4/user_service/domain/transaction/db/Transaction.java
+++ b/user-service/src/main/java/rs/banka4/user_service/domain/transaction/db/Transaction.java
@@ -55,7 +55,7 @@ public class Transaction {
         @AssociationOverride(
             name = "currency",
             joinColumns = @JoinColumn(
-                name = "from_currency_id",
+                name = "from_currency_code",
                 nullable = false
             )
         )
@@ -76,7 +76,7 @@ public class Transaction {
         @AssociationOverride(
             name = "currency",
             joinColumns = @JoinColumn(
-                name = "to_currency_id",
+                name = "to_currency_code",
                 nullable = false
             )
         )
@@ -93,7 +93,7 @@ public class Transaction {
     @AssociationOverrides({
         @AssociationOverride(
             name = "currency",
-            joinColumns = @JoinColumn(name = "fee_currency_id")
+            joinColumns = @JoinColumn(name = "fee_currency_code")
         )
     })
     private MonetaryAmount fee;

--- a/user-service/src/main/java/rs/banka4/user_service/service/mock/generators/AccountObjectMother.java
+++ b/user-service/src/main/java/rs/banka4/user_service/service/mock/generators/AccountObjectMother.java
@@ -99,14 +99,7 @@ public class AccountObjectMother {
         account.setDailyLimit(BigDecimal.valueOf(1000.00));
         account.setMonthlyLimit(BigDecimal.valueOf(10000.00));
         account.setCurrency(
-            new Currency(
-                UUID.randomUUID(),
-                "Serbian Dinar",
-                "RSD",
-                "Serbian Dinar currency",
-                true,
-                Currency.Code.RSD
-            )
+            new Currency(Currency.Code.RSD, "Serbian Dinar", "RSD", "Serbian Dinar currency", true)
         );
         account.setEmployee(EmployeeObjectMother.generateBasicEmployee());
         account.setClient(
@@ -128,14 +121,7 @@ public class AccountObjectMother {
         account.setDailyLimit(BigDecimal.valueOf(1000.00));
         account.setMonthlyLimit(BigDecimal.valueOf(10000.00));
         account.setCurrency(
-            new Currency(
-                UUID.randomUUID(),
-                "Serbian Dinar",
-                "RSD",
-                "Serbian Dinar currency",
-                true,
-                Currency.Code.RSD
-            )
+            new Currency(Currency.Code.RSD, "Serbian Dinar", "RSD", "Serbian Dinar currency", true)
         );
         account.setEmployee(EmployeeObjectMother.generateBasicEmployee());
         account.setClient(

--- a/user-service/src/main/resources/db/migration/V2025.203.31.1743457815__drop_artificial_currency_ids.sql
+++ b/user-service/src/main/resources/db/migration/V2025.203.31.1743457815__drop_artificial_currency_ids.sql
@@ -1,0 +1,86 @@
+-- Drop the artificial UUID from currencies, let them be identified via their
+-- currency code only.
+
+-- Make currency.code mandatory.
+ALTER TABLE currencies ALTER COLUMN code SET NOT NULL;
+
+ALTER TABLE accounts
+      DROP CONSTRAINT fk_accounts_on_currency;
+ALTER TABLE transactions
+      DROP CONSTRAINT fk_fee_currency;
+ALTER TABLE transactions
+      DROP CONSTRAINT fk_from_currency;
+ALTER TABLE loan_requests
+      DROP CONSTRAINT fk_loan_requests_on_currency;
+ALTER TABLE transactions
+      DROP CONSTRAINT fk_to_currency;
+
+-- Change primary key of currency table.
+ALTER TABLE currencies DROP CONSTRAINT pk_currencies;
+ALTER TABLE currencies ADD CONSTRAINT pk_currencies PRIMARY KEY (code);
+
+-- Due to the FKs above, the following queries should always produce the right
+-- currency code.
+
+-- Rework 'accounts' table.
+ALTER TABLE accounts
+      ADD COLUMN currency_code VARCHAR(255);
+UPDATE accounts AS acc
+       SET currency_code = (SELECT code FROM currencies AS c
+                                        WHERE c.id = acc.currency_id);
+ALTER TABLE accounts
+      DROP COLUMN currency_id;
+ALTER TABLE accounts
+      ADD CONSTRAINT fk_accounts_on_currency FOREIGN KEY (currency_code)
+          REFERENCES currencies (code);
+
+
+-- Rework 'transactions' table.
+ALTER TABLE transactions
+      ADD COLUMN fee_currency_code VARCHAR(255);
+UPDATE transactions AS tx
+       SET fee_currency_code = (SELECT code FROM currencies AS c
+                                            WHERE c.id = tx.fee_currency_id);
+ALTER TABLE transactions
+      DROP COLUMN fee_currency_id;
+ALTER TABLE transactions
+      ADD CONSTRAINT fk_fee_currency FOREIGN KEY (fee_currency_code)
+          REFERENCES currencies (code);
+
+ALTER TABLE transactions
+      ADD COLUMN from_currency_code VARCHAR(255);
+UPDATE transactions AS tx
+       SET from_currency_code = (SELECT code FROM currencies AS c
+                                             WHERE c.id = tx.from_currency_id);
+ALTER TABLE transactions
+      DROP COLUMN from_currency_id;
+ALTER TABLE transactions
+      ADD CONSTRAINT fk_from_currency FOREIGN KEY (from_currency_code)
+          REFERENCES currencies (code);
+
+ALTER TABLE transactions
+      ADD COLUMN to_currency_code VARCHAR(255);
+UPDATE transactions AS tx
+       SET to_currency_code = (SELECT code FROM currencies AS c
+                                           WHERE c.id = tx.to_currency_id);
+ALTER TABLE transactions
+      DROP COLUMN to_currency_id;
+ALTER TABLE transactions
+      ADD CONSTRAINT fk_to_currency FOREIGN KEY (to_currency_code)
+          REFERENCES currencies (code);
+
+
+-- Rework 'loan_requests' table.
+ALTER TABLE loan_requests
+      ADD COLUMN currency_code VARCHAR(255);
+UPDATE loan_requests AS lrq
+       SET currency_code = (SELECT code FROM currencies AS c
+                                        WHERE c.id = lrq.currency_id);
+ALTER TABLE loan_requests
+      DROP COLUMN currency_id;
+ALTER TABLE loan_requests
+      ADD CONSTRAINT fk_loan_requests_on_currency FOREIGN KEY (currency_code)
+          REFERENCES currencies (code);
+
+-- Drop ID column, finally.
+ALTER TABLE currencies DROP COLUMN id;

--- a/user-service/src/test/java/rs/banka4/user_service/generator/AccountObjectMother.java
+++ b/user-service/src/test/java/rs/banka4/user_service/generator/AccountObjectMother.java
@@ -127,14 +127,7 @@ public class AccountObjectMother {
         account.setDailyLimit(BigDecimal.valueOf(1000.00));
         account.setMonthlyLimit(BigDecimal.valueOf(10000.00));
         account.setCurrency(
-            new Currency(
-                UUID.randomUUID(),
-                "Serbian Dinar",
-                "RSD",
-                "Serbian Dinar currency",
-                true,
-                Currency.Code.RSD
-            )
+            new Currency(Currency.Code.RSD, "Serbian Dinar", "RSD", "Serbian Dinar currency", true)
         );
         account.setEmployee(EmployeeObjectMother.generateBasicEmployee());
         account.setClient(
@@ -156,14 +149,7 @@ public class AccountObjectMother {
         account.setDailyLimit(BigDecimal.valueOf(1000.00));
         account.setMonthlyLimit(BigDecimal.valueOf(10000.00));
         account.setCurrency(
-            new Currency(
-                UUID.randomUUID(),
-                "European Currency",
-                "EUR",
-                "European currency",
-                true,
-                Currency.Code.EUR
-            )
+            new Currency(Currency.Code.EUR, "European Currency", "EUR", "European currency", true)
         );
         account.setEmployee(EmployeeObjectMother.generateBasicEmployee());
         account.setClient(
@@ -185,14 +171,7 @@ public class AccountObjectMother {
         account.setDailyLimit(BigDecimal.valueOf(1000.00));
         account.setMonthlyLimit(BigDecimal.valueOf(10000.00));
         account.setCurrency(
-            new Currency(
-                UUID.randomUUID(),
-                "Serbian Dinar",
-                "RSD",
-                "Serbian Dinar currency",
-                true,
-                Currency.Code.RSD
-            )
+            new Currency(Currency.Code.RSD, "Serbian Dinar", "RSD", "Serbian Dinar currency", true)
         );
         account.setEmployee(EmployeeObjectMother.generateBasicEmployee());
         account.setClient(

--- a/user-service/src/test/java/rs/banka4/user_service/generator/LoanObjectMother.java
+++ b/user-service/src/test/java/rs/banka4/user_service/generator/LoanObjectMother.java
@@ -2,7 +2,6 @@ package rs.banka4.user_service.generator;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.UUID;
 import rs.banka4.user_service.domain.currency.db.Currency;
 import rs.banka4.user_service.domain.loan.db.Loan;
 import rs.banka4.user_service.domain.loan.db.LoanStatus;
@@ -43,14 +42,7 @@ public class LoanObjectMother {
             LocalDate.now()
                 .plusDays(30),
             BigDecimal.valueOf(900.00),
-            new Currency(
-                UUID.randomUUID(),
-                "Serbian Dinar",
-                "RSD",
-                "Serbian Dinar currency",
-                true,
-                Currency.Code.RSD
-            ),
+            new Currency(Currency.Code.RSD, "Serbian Dinar", "RSD", "Serbian Dinar currency", true),
             LoanStatus.APPROVED,
             Loan.InterestType.FIXED
         );

--- a/user-service/src/test/java/rs/banka4/user_service/generator/TransactionObjectMother.java
+++ b/user-service/src/test/java/rs/banka4/user_service/generator/TransactionObjectMother.java
@@ -73,9 +73,9 @@ public class TransactionObjectMother {
             .transactionNumber("1265463698391")
             .fromAccount(fromAccount)
             .toAccount(toAccount)
-            .from(new MonetaryAmount(BigDecimal.valueOf(1.00), generateCurrency("EUR")))
-            .to(new MonetaryAmount(BigDecimal.valueOf(1.00), generateCurrency("RSD")))
-            .fee(new MonetaryAmount(BigDecimal.valueOf(0.10), generateCurrency("EUR")))
+            .from(new MonetaryAmount(BigDecimal.valueOf(1.00), generateCurrency(Currency.Code.EUR)))
+            .to(new MonetaryAmount(BigDecimal.valueOf(1.00), generateCurrency(Currency.Code.RSD)))
+            .fee(new MonetaryAmount(BigDecimal.valueOf(0.10), generateCurrency(Currency.Code.EUR)))
             .recipient("Milutin Joncic")
             .paymentCode("289")
             .referenceNumber("1176926")
@@ -85,14 +85,13 @@ public class TransactionObjectMother {
             .build();
     }
 
-    public static Currency generateCurrency(String code) {
+    public static Currency generateCurrency(Currency.Code code) {
         return Currency.builder()
-            .id(UUID.randomUUID())
             .name("Fake")
             .symbol("X")
             .description("Fake currency")
             .active(true)
-            .code(Currency.Code.fromString(code))
+            .code(code)
             .build();
     }
 

--- a/user-service/src/test/java/rs/banka4/user_service/unit/loan/GetAllLoansTests.java
+++ b/user-service/src/test/java/rs/banka4/user_service/unit/loan/GetAllLoansTests.java
@@ -98,12 +98,11 @@ public class GetAllLoansTests {
                     .plusMonths(1),
                 BigDecimal.valueOf(5000),
                 new Currency(
-                    UUID.randomUUID(),
+                    Currency.Code.RSD,
                     "Serbian Dinar",
                     "RSD",
                     "Serbian Dinar currency",
-                    true,
-                    Currency.Code.RSD
+                    true
                 ),
                 LoanStatus.APPROVED,
                 Loan.InterestType.FIXED
@@ -123,12 +122,11 @@ public class GetAllLoansTests {
                     .plusMonths(1),
                 BigDecimal.valueOf(5000),
                 new Currency(
-                    UUID.randomUUID(),
+                    Currency.Code.RSD,
                     "Serbian Dinar",
                     "RSD",
                     "Serbian Dinar currency",
-                    true,
-                    Currency.Code.RSD
+                    true
                 ),
                 LoanStatus.APPROVED,
                 Loan.InterestType.FIXED
@@ -149,12 +147,11 @@ public class GetAllLoansTests {
                     .plusMonths(1),
                 BigDecimal.valueOf(5000),
                 new Currency(
-                    UUID.randomUUID(),
+                    Currency.Code.RSD,
                     "Serbian Dinar",
                     "RSD",
                     "Serbian Dinar currency",
-                    true,
-                    Currency.Code.RSD
+                    true
                 ),
                 LoanStatus.APPROVED,
                 Loan.InterestType.FIXED
@@ -174,7 +171,7 @@ public class GetAllLoansTests {
         loan1.setAccount(account1);
 
         Currency currency = new Currency();
-        currency.setId(UUID.randomUUID());
+        currency.setCode(Currency.Code.EUR);
         currency.setName("EUR");
         currency.setActive(true);
         currency.setSymbol("E");

--- a/user-service/src/test/java/rs/banka4/user_service/unit/loan/ListingLoansTests.java
+++ b/user-service/src/test/java/rs/banka4/user_service/unit/loan/ListingLoansTests.java
@@ -74,8 +74,8 @@ public class ListingLoansTests {
 
         UUID accountId = UUID.randomUUID();
 
-        rs.banka4.user_service.domain.currency.db.Currency currency = new Currency();
-        currency.setId(UUID.randomUUID());
+        Currency currency = new Currency();
+        currency.setCode(Currency.Code.EUR);
         currency.setName("EUR");
         currency.setActive(true);
         currency.setSymbol("E");

--- a/user-service/src/test/java/rs/banka4/user_service/unit/transaction/TransactionServiceGetTests.java
+++ b/user-service/src/test/java/rs/banka4/user_service/unit/transaction/TransactionServiceGetTests.java
@@ -218,7 +218,7 @@ public class TransactionServiceGetTests {
         String token = "mocked-token";
         Account fromAccount = AccountObjectMother.generateBasicFromAccount();
         Account toAccount = AccountObjectMother.generateBasicToAccount();
-        Currency currency = TransactionObjectMother.generateCurrency("EUR");
+        Currency currency = TransactionObjectMother.generateCurrency(Currency.Code.EUR);
 
         Transaction transaction1 =
             TransactionObjectMother.generateTransaction(

--- a/user-service/src/test/java/rs/banka4/user_service/unit/transaction/TransactionServiceProcessingTests.java
+++ b/user-service/src/test/java/rs/banka4/user_service/unit/transaction/TransactionServiceProcessingTests.java
@@ -42,11 +42,11 @@ public class TransactionServiceProcessingTests {
     void testProcessTransactionSameCurrency() {
         // Arrange
         Account fromAccount = new Account();
-        fromAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        fromAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         fromAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account toAccount = new Account();
-        toAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        toAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         toAccount.setBalance(BigDecimal.valueOf(500));
 
         BigDecimal amount = BigDecimal.valueOf(100);
@@ -73,11 +73,11 @@ public class TransactionServiceProcessingTests {
     void testProcessTransactionRsdToForeign() {
         // Arrange
         Account fromAccount = new Account();
-        fromAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        fromAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         fromAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account toAccount = new Account();
-        toAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        toAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         toAccount.setBalance(BigDecimal.valueOf(500));
 
         BigDecimal amount = BigDecimal.valueOf(100);
@@ -89,11 +89,11 @@ public class TransactionServiceProcessingTests {
             .thenReturn(BigDecimal.valueOf(1));
 
         Account rsdBankAccount = new Account();
-        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         rsdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account usdBankAccount = new Account();
-        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         usdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         when(bankAccountServiceImpl.getBankAccountForCurrency(Currency.Code.RSD)).thenReturn(
@@ -123,11 +123,11 @@ public class TransactionServiceProcessingTests {
     void testProcessTransactionForeignToRsd() {
         // Arrange
         Account fromAccount = new Account();
-        fromAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        fromAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         fromAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account toAccount = new Account();
-        toAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        toAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         toAccount.setBalance(BigDecimal.valueOf(500));
 
         BigDecimal amount = BigDecimal.valueOf(100);
@@ -139,11 +139,11 @@ public class TransactionServiceProcessingTests {
             .thenReturn(BigDecimal.valueOf(1000));
 
         Account usdBankAccount = new Account();
-        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         usdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account rsdBankAccount = new Account();
-        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         rsdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         when(bankAccountServiceImpl.getBankAccountForCurrency(Currency.Code.USD)).thenReturn(
@@ -173,11 +173,11 @@ public class TransactionServiceProcessingTests {
     void testProcessTransactionForeignToForeign() {
         // Arrange
         Account fromAccount = new Account();
-        fromAccount.setCurrency(TransactionObjectMother.generateCurrency("EUR"));
+        fromAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.EUR));
         fromAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account toAccount = new Account();
-        toAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        toAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         toAccount.setBalance(BigDecimal.valueOf(500));
 
         BigDecimal amount = BigDecimal.valueOf(100);
@@ -196,15 +196,15 @@ public class TransactionServiceProcessingTests {
         ).thenReturn(BigDecimal.valueOf(1));
 
         Account eurBankAccount = new Account();
-        eurBankAccount.setCurrency(TransactionObjectMother.generateCurrency("EUR"));
+        eurBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.EUR));
         eurBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account rsdBankAccount = new Account();
-        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("RSD"));
+        rsdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.RSD));
         rsdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         Account usdBankAccount = new Account();
-        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency("USD"));
+        usdBankAccount.setCurrency(TransactionObjectMother.generateCurrency(Currency.Code.USD));
         usdBankAccount.setBalance(BigDecimal.valueOf(1000));
 
         when(bankAccountServiceImpl.getBankAccountForCurrency(Currency.Code.EUR)).thenReturn(


### PR DESCRIPTION
The `Currency` ID field is redundant - the currency code already uniquely
identifies currencies.  Removing the redundant UUIDs makes it easier to deal
with the currency table when having to ad-hoc something.