### PR TITLE
bank: make ListingSpecification#isLatest ~24040.38 times cheaper

### DIFF
--- a/bank-service/src/main/java/rs/banka4/bank_service/domain/listing/specificaion/ListingSpecification.java
+++ b/bank-service/src/main/java/rs/banka4/bank_service/domain/listing/specificaion/ListingSpecification.java
@@ -247,17 +247,14 @@ public class ListingSpecification {
             final var subquery = query.subquery(OffsetDateTime.class);
             final var subRoot = subquery.from(Listing.class);
 
-            subquery.select(cb.greatest(subRoot.get(Listing_.lastRefresh)))
-                .where(
-                    cb.equal(
-                        subRoot.get(Listing_.security)
-                            .get(Security_.id),
-                        root.get(Listing_.security)
-                            .get(Security_.id)
-                    )
+            return root.get(Listing_.lastRefresh)
+                .in(
+                    subquery.select(cb.greatest(subRoot.get(Listing_.lastRefresh)))
+                        .groupBy(
+                            subRoot.get(Listing_.security)
+                                .get(Security_.id)
+                        )
                 );
-
-            return cb.equal(root.get(Listing_.lastRefresh), subquery);
         });
     }
 


### PR DESCRIPTION
according to the pgsql query planner, using an independent query in
order to yield a "last refresh" value for all securities produces a
query with cost 2885.25 when analyzed against our current dataset,
whereas the cost of the old query that this specification would create
is 69362511.78.  do note that the latter lacks the analysis based on
data-set, as I was forced to use EXPLAIN over EXPLAIN ANALYSE because
the EXPLAIN ANALYSE I started has been running for an hour at the time
of writing.

this query is suboptimal, but we're dealing with a limitation of JQL: we
cannot select tuples in subqueries to check against.  this query is, as
a result, approximate, unless lastRefresh are unique, which there is no
guarantee of (but a high likelihood of regardless).  oh well.  I don't
care enough to fix it.